### PR TITLE
Certifying specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The language itself is meant to be simple, since it's intended to only describe 
 
 # Status
 
-Sligh is an experiment and a prototype. The test compiler does function, but it currently assumes a very specific implementation setup: a Next.js application that uses Zustand for state management. The hope is to generalize the compiler so that different backends can be built to target different implementation architectures / patterns.
+Sligh is an experiment and a prototype. The test compiler does function, but it currently assumes a very specific implementation setup: a Next.js application that uses Zustand for state management, and is tested via fast-check. The hope is to generalize the compiler so that different backends can be built to target different implementation architectures / patterns.
 
 # Setup
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+# Setup
+
+```
+brew install ocaml
+brew install opam
+opam install dune
+
+dune build
+```
+
+There are several test applications, for example `./gendeno` creates a Deno test from the `budget2.sl` Budget app model.
+
+# Model-driven Test Generation
+
+
+
 # Model-driven Implementation Derivation and Test Generation
 
 This is a pivot on the idea in [Sligh](https://github.com/amw-zero/sligh). The same general goal applies: the language should enable a [model-driven workflow](https://concerningquality.com/model-based-testing/) that automates as much of the implementation and test generation and possible.

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The language itself is meant to be simple, since it's intended to only describe 
 
 # Status
 
-Sligh is an experiment and a prototype. The test compiler does function, but it currently assumes a very specific implementation setup: a Next.js application that uses Zustand for state management, and is tested via fast-check. The hope is to generalize the compiler so that different backends can be built to target different implementation architectures / patterns.
+Sligh is an experiment and a prototype. The test compiler does function, but it currently assumes a very specific implementation setup: a [Next.js](https://nextjs.org/) application that uses [Zustand](https://github.com/pmndrs/zustand) for state management, and is tested via [fast-check](https://github.com/dubzzz/fast-check). The hope is to generalize the compiler so that different backends can be built to target different implementation architectures / patterns.
 
 # Setup
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,46 @@
+# Description
+
+Sligh is a language and toolchain for model-based testing. With Sligh, you write a simplified model of a system, and the compiler uses it to generate a test suite for an implementation system. The model becomes an executable specification that the test uses to determine correct behavior.
+
+Here's a Sligh model of a simple counter application:
+
+```
+record Counter:
+    name: Id(String)
+    value: Int
+end
+
+process CounterApp:
+  counters: Set(Counter)
+
+  def GetCounters():
+      counters
+  end
+
+  def CreateCounter(name: String):
+      counters := counters.append(Counter.new(name, 0))
+  end
+
+  def Increment(name: String):
+    def findCounter(counter: Counter):
+        counter.name.equalsStr(name)
+    end
+
+    def updateCounter(counter: Counter):
+        Counter.new(counter.name, counter.value + 1)
+    end
+
+    counters := counters.update(findCounter, updateCounter)
+  end
+end
+```
+
+The language itself is meant to be simple, since it's intended to only describe the high-level logic of a system. 
+
+# Status
+
+Sligh is an experiment and a prototype. The test compiler does function, but it currently assumes a very specific implementation setup: a Next.js application that uses Zustand for state management. The hope is to generalize the compiler so that different backends can be built to target different implementation architectures / patterns.
+
 # Setup
 
 ```
@@ -5,112 +48,13 @@ brew install ocaml
 brew install opam
 opam install dune
 
-dune build
+dune build && dune install
 ```
 
-There are several test applications, for example `./gendeno` creates a Deno test from the `budget2.sl` Budget app model.
+# Usage
 
-# Model-driven Test Generation
-
-
-
-# Model-driven Implementation Derivation and Test Generation
-
-This is a pivot on the idea in [Sligh](https://github.com/amw-zero/sligh). The same general goal applies: the language should enable a [model-driven workflow](https://concerningquality.com/model-based-testing/) that automates as much of the implementation and test generation and possible.
-
-The main difference of this approach is that here, implementation derivation happens via metaprogramming vs. being compiled without any intervention. This places more burden of work on the programmer, but there's basically infinite control on the generated output.
-
-As an example (this won't fully compile today, but is the overall goal):
-
-**Model**:
+Generates a witness object intended to be used in a test generator.
 
 ```
-entity Todo:
-  name: String
-end
-
-domain Test:
-  todos: Todo[]
-
-  def addTodo(t: Todo.Create):
-    todos.create!(t)
-  end
-end
+sligh model.sl -cert <output file>
 ```
-
-This is a simple model of a todo app. `create!` now denotes an _effect_ which is an operation that has different definitions in the model and implementation. Effects are hand-implemented via metaprogramming:
-
-**Effects**:
-```
-// Effect definition - how is an effect executed
-// across implementation components?
-effect create!<'a>(state: SystemState<'a>, val: 'a):
-  model: 
-    state.push(val)
-  end
-
-  // Client code generated from model definitions
-  client:
-    typescript:
-      let resp = fetch({{ state.name }}, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({{ val }}),
-      });
-      let data = await resp.json();
-
-      client.todos.push(data);
-    end
-  end
-
-  server:
-    // Generate endpoint code in same way
-  end
-end
-```
-
-Here we generated the client implementation of a `create!` effect, which simply sends a POST request to the proper endpoint. The key here is that we're defining the client definition in a `typescript` block, which is a quasi-quotation block for defining TypeScript code. `{{ ... }}` unquotes / splices, so the TS client can be generated from definitions in the model.
-
-And putting it all together, we need to define the top-level application processes that are the entry point for each system component:
-
-**Processes**:
-```
-// Helpers to convert model definitions to TS
-def toTsTypedIden(var: Variable)
-  typescript:
-    {{ var.name }}: {{ var.type }}
-  end
-end
-
-def toTsAction(act: Action)
-  typescript:
-    async {{ act.name }}({{ act.args.map(toTsTypedIden) }}) {
-      {{ act.body }}
-    }
-  end
-end
-
-// Generates a client.ts file.
-//
-// This is a stateful class which holds all of the state variables
-// declared the model, and since toTsAction is called in a client block 
-// here, the client effect definition is used as the action body.
-process client:
-  typescript:
-    class Client {
-      {{ Model.variables.map(toTsTypedIden) }}
-
-      {{ Model.actions.map(toTsAction) }}
-    }
-  end
-end
-
-// Generates a server.ts file
-process server:
-  // generate web server bootstrap
-end
-```
-
-I omitted the server code for brevity, but that can all be generated from the Model in the same way.
-
-We didn't cover test generation, but with even less help, a model-based test can be generated here since we have all of the definitions that we need to compare actions in the implementation and model.

--- a/Subprocess.thy
+++ b/Subprocess.thy
@@ -8,7 +8,7 @@ text "A simpler version of assume-guarantee reasoning that focuses on non-interf
       updates alone, e.g. https://arxiv.org/pdf/2103.13743.pdf"
 text "Goes back to Lamport & Abadi: https://lamport.azurewebsites.net/pubs/abadi-conjoining.pdf"
 
-text "Each action operates on its own state, which is defined as a 'v view type. The relationship
+text "Each action operates on its own local state, which is defined as a 'v view type. The relationship
      between 'v and 's is definable by a lens. This is different than the seL4 process model,
       since that effectively only has a single lens whereas multiple lenses are required for
       each action here."
@@ -61,7 +61,7 @@ definition "local_simulates am_i am_m e s t = (
   let impl_start = (Get (lens (am_i e))) s in
   let model_start = (Get (lens (am_m e))) s in
 
-  (proc_i impl_start = t) \<longrightarrow> (proc_m model_start = t))"
+  proc_i impl_start = t \<longrightarrow> proc_m model_start = t)"
 
 text "Basic notion of simulation."
 
@@ -103,13 +103,15 @@ definition "local_invariant am inv_f e s = (
   let local_state = Get (lens (am e)) s in
   let put = Put (lens (am e)) in
 
-
    inv_f s \<and> inv_f (put (step_f local_state) s)
 )"
 
+text "Local invariance implies global invariance.
+
+     Note how well-behavedness of the lens isn't a required assumption, because all that matters
+     is that the invariant holds before and after the action completes."
 theorem local_inv_imp_inv:
-  assumes "well_behaved (lens (am_i e))"
-    and "local_invariant am_i inv_f e s"
+  assumes "local_invariant am_i inv_f e s"
   shows "inv_f ((compose_local_actions am_i) e s)"
   using assms
   unfolding well_behaved_def local_invariant_def compose_local_actions_def

--- a/Subprocess.thy
+++ b/Subprocess.thy
@@ -4,9 +4,131 @@ imports Main
 
 begin
 
+text "Related to assume-guarantee reasoning, e.g. https://arxiv.org/pdf/2103.13743.pdf"
+text "Goes back to Lamport & Abadi: https://lamport.azurewebsites.net/pubs/abadi-conjoining.pdf"
+
+section "Step function only"
+
+text "Each action operates on its own state, which is defined as a 'v view type that's
+      definable by a lens on the state type. This is different than the seL4 process model,
+      since that effectively only has a single lens whereas multiple lenses are required for
+      each action here."
+
 record ('s, 'v) lens  = 
   Get :: "'s \<Rightarrow> 'v"
   Put :: "'v \<Rightarrow> 's \<Rightarrow> 's"
+
+type_synonym ('e, 's) process = "'e \<Rightarrow> 's \<Rightarrow> 's"
+
+definition exec :: "('e, 's) process \<Rightarrow> 'e list \<Rightarrow> 's \<Rightarrow> 's" where
+"exec step es i = foldl (\<lambda>s e. step e s) i es"
+
+record ('s, 'a) subaction =
+  salens :: "('s, 'a) lens"
+  sastep :: "'a \<Rightarrow> 'a"
+
+type_synonym ('e, 's, 'a) action_mapping = "'e \<Rightarrow> ('s, 'a) subaction"
+
+definition compose_subactions :: "('e, 's, 'a) action_mapping \<Rightarrow> ('e, 's) process"  where
+"compose_subactions spmap = (\<lambda>e s.(
+  let subproc = spmap e in
+  let lns = (salens subproc) in
+  let stp = (sastep subproc) in
+  let v = (Get lns) s in
+  let res = stp v in
+  
+  (Put lns) res s
+))"
+
+(* lemma - a process built with compose_subactions is equivalent to a process defined without it? *)
+
+text "'Action Refinement' is where each isolated implementation action refines its corresponding
+    action in the model. The state type of the step function vfn is local to the action and does
+    not refer to the global state in any way."
+
+definition "single_action_refines proc_i proc_m = (\<forall>ss ss'. proc_i ss = ss' \<longrightarrow> proc_m ss = ss')"
+
+definition "action_refines am_i am_m e =
+  (let proc_i = sastep (am_i e) in 
+  let proc_m = sastep (am_m e) in
+
+  single_action_refines proc_i proc_m)"
+
+definition "refines impl_proc model_proc es = (\<forall>s. exec impl_proc es = s \<longrightarrow> exec model_proc es = s)"
+
+lemma local_refinement:
+  assumes "action_refines am_i am_m e"
+  shows "single_action_refines (sastep (am_i e)) (sastep (am_m e))"
+proof -
+  have "action_refines am_i am_m e" by fact
+  then have "single_action_refines (sastep (am_i e)) (sastep (am_m e))" 
+    unfolding action_refines_def single_action_refines_def
+    by auto
+  then show ?thesis by simp
+qed
+
+lemma composed_subactions_refinement:
+  assumes "\<And> e. e \<in> set es \<Longrightarrow> action_refines am_i am_m e"
+  shows "refines (compose_subactions am_i) (compose_subactions am_m) es"
+proof (induction es)
+  case Nil
+  then show ?case unfolding exec_def refines_def by simp
+next
+  case (Cons e es)
+  from Cons.prems have "action_refines am_i am_m e"  by simp
+  from local_refinement[OF this, of e] have "single_action_refines (sastep (am_i e)) (sastep (am_m e))" by auto
+  with Cons.IH Cons.prems show ?case
+    unfolding refines_def exec_def compose_subactions_def single_action_refines_def
+    by (auto simp add: Let_def)
+qed
+
+theorem main_theorem:
+  assumes "model_proc = compose_subactions am_m"
+    and "impl_proc = compose_subactions am_i"
+    and "\<And>e. e \<in> set es \<Longrightarrow> action_refines am_i am_m e"
+  shows "refines impl_proc model_proc es"
+  using assms composed_subactions_refinement
+  by auto
+
+text "Action refinement implies refinement of the processes with global state, provided that 
+    each process at the global level's step function is defined via the 'compose_subprocs' 
+    function"
+
+text "Need to relate action_refines to global execution"
+
+(* If a model and implementation can be built by composing sub-actions together,
+   and the individal actions refine each other at the local level,
+   then the global implementation refines the global model. *)
+theorem 
+  assumes
+    "model_proc = compose_subactions am_m" and
+    "impl_proc =  compose_subactions am_i" and
+    "action_refines am_i am_m"
+  shows "refines impl_proc model_proc es"
+proof(induction es arbitrary: s am_i am_m)
+  case Nil
+  then show ?case unfolding exec_def refines_def by simp
+next
+  case (Cons a es)
+  then show ?case
+    sorry
+  qed
+
+definition "simulates impl_proc model_proc= (\<forall>e s s'.
+  impl_proc e s = s' \<longrightarrow> model_proc e s = s')"
+
+theorem
+  assumes "simulates I M"
+  shows "refines I M es"
+  oops
+
+
+(* 
+
+GlobalState |> ActionLens.Get |> Action |> ActionLens.Put
+
+*)
+
 
 record ('s, 'e) dt =
   state :: 's
@@ -45,21 +167,12 @@ definition compose_subprocs :: "('e, 's, 'v) subproc_mapping \<Rightarrow> ('e, 
   (Put lns) res s
 ))"
 
-text "'Action Refinement' is where each isolated implementation action refines its corresponding
-    action in the model. The state type of the step function vfn is local to the action and does
-    not refer to the global state in any way."
-
-definition "single_action_refines stp_i stp_m = (\<forall>ss ss'. stp_i ss = ss' \<longrightarrow> stp_m ss = ss')"
-
-definition "action_refines spmi spmm = (\<forall>e.
-  let stp_i = spstep (spmi e) in 
-  let stp_m = spstep (spmm e) in
-
-  single_action_refines stp_i stp_m)"
-
-text "Action refinement implies refinement of the processes with global state, provided that 
-    each process at the global level's step function is defined via the 'compose_subprocs' 
-    function"
+(* Some equivalence between a process and its decomposition into a set of subprocesses"
+theorem
+  assumes "proc = \<lparr> state=s, step=step \<rparr>"
+    and   "subproc = 
+  shows proc_subproc_equiv: "x = y"
+*)
 
 definition "refines_dt C M = (\<forall>s s' es. exec_dt C s es = s' \<longrightarrow> exec_dt M s es = s')"
 
@@ -78,6 +191,7 @@ next
     unfolding compose_subprocs_def action_refines_def single_action_refines_def refines_dt_def 
       exec_dt_def Let_def
     sorry
+   
 qed
 
 section "Subprocs for banking"

--- a/bin/sligh.ml
+++ b/bin/sligh.ml
@@ -52,7 +52,7 @@ let main = begin
   else if !impl_out <> "" then
     Compiler.compile_cert_model_transform !input_file !impl_out !cert_out
   else if !impl_in <> "" then
-    Compiler.compile_spec !input_file !impl_in !cert_out
+    Compiler.compile_spec !input_file !impl_in !cert_out !out_file
   else
     let out_file_name = if !out_file = "" then "model" else !out_file in
     Compiler.compile_model !input_file out_file_name

--- a/bin/sligh.ml
+++ b/bin/sligh.ml
@@ -47,12 +47,12 @@ let args = [
 let main = begin
   Arg.parse args set_input usage_msg;  
 
-  if !transform_script <> "" then
+  if !cert_out <> "" then
+    Compiler.compile_cert_test !input_file !cert_out
+  else if !transform_script <> "" then
     Compiler.compile_model_transform !input_file !transform_script !out_file
   else if !impl_out <> "" then
     Compiler.compile_cert_model_transform !input_file !impl_out !cert_out
-  else if !impl_in <> "" then
-    Compiler.compile_cert_test !input_file !impl_in !cert_out !out_file
   else
     let out_file_name = if !out_file = "" then "model" else !out_file in
     Compiler.compile_model !input_file out_file_name

--- a/bin/sligh.ml
+++ b/bin/sligh.ml
@@ -52,7 +52,7 @@ let main = begin
   else if !impl_out <> "" then
     Compiler.compile_cert_model_transform !input_file !impl_out !cert_out
   else if !impl_in <> "" then
-    Compiler.compile_spec !input_file !impl_in !cert_out !out_file
+    Compiler.compile_cert_test !input_file !impl_in !cert_out !out_file
   else
     let out_file_name = if !out_file = "" then "model" else !out_file in
     Compiler.compile_model !input_file out_file_name

--- a/budget2.sl
+++ b/budget2.sl
@@ -25,7 +25,7 @@ process Budget:
   recurringTransactions: Set(RecurringTransaction)
   scheduledTransactions: Set(ScheduledTransaction)
 
-  def AddRecurringTransaction(crt: RecurringTransaction, id: Int):
+  def AddRecurringTransaction(crt: CreateRecurringTransaction, id: Int):
     recurringTransactions := recurringTransactions.append(RecurringTransaction.new(
       id, crt.name, crt.amount, crt.rule
     ))

--- a/counter.sl
+++ b/counter.sl
@@ -1,0 +1,7 @@
+process Counter:
+    value: Int
+
+    def Increment():
+        value := value + 1
+    end
+end

--- a/gencert
+++ b/gencert
@@ -1,7 +1,2 @@
 #!/usr/bin/env sh
-dune exec sligh cert-spec.sl -- -cert cert.ts -include Model
-
-
-# sligh cert-spec.sl -transform impl.sl
-# sligh cert-spec.sl -transform simulation.sl
-# sligh cert-spec.sl
+dune exec sligh budget2.sl -- -cert cert -include Model

--- a/gencert
+++ b/gencert
@@ -1,2 +1,2 @@
 #!/usr/bin/env sh
-dune exec sligh budget2.sl -- -cert cert -include Model
+dune exec sligh counter.sl -- -cert cert -include Model

--- a/implementation-generation.md
+++ b/implementation-generation.md
@@ -1,0 +1,104 @@
+# Model-driven Test Generation
+
+
+
+# Model-driven Implementation Derivation and Test Generation
+
+This is a pivot on the idea in [Sligh](https://github.com/amw-zero/sligh). The same general goal applies: the language should enable a [model-driven workflow](https://concerningquality.com/model-based-testing/) that automates as much of the implementation and test generation and possible.
+
+The main difference of this approach is that here, implementation derivation happens via metaprogramming vs. being compiled without any intervention. This places more burden of work on the programmer, but there's basically infinite control on the generated output.
+
+As an example (this won't fully compile today, but is the overall goal):
+
+**Model**:
+
+```
+entity Todo:
+  name: String
+end
+
+domain Test:
+  todos: Todo[]
+
+  def addTodo(t: Todo.Create):
+    todos.create!(t)
+  end
+end
+```
+
+This is a simple model of a todo app. `create!` now denotes an _effect_ which is an operation that has different definitions in the model and implementation. Effects are hand-implemented via metaprogramming:
+
+**Effects**:
+```
+// Effect definition - how is an effect executed
+// across implementation components?
+effect create!<'a>(state: SystemState<'a>, val: 'a):
+  model: 
+    state.push(val)
+  end
+
+  // Client code generated from model definitions
+  client:
+    typescript:
+      let resp = fetch({{ state.name }}, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({{ val }}),
+      });
+      let data = await resp.json();
+
+      client.todos.push(data);
+    end
+  end
+
+  server:
+    // Generate endpoint code in same way
+  end
+end
+```
+
+Here we generated the client implementation of a `create!` effect, which simply sends a POST request to the proper endpoint. The key here is that we're defining the client definition in a `typescript` block, which is a quasi-quotation block for defining TypeScript code. `{{ ... }}` unquotes / splices, so the TS client can be generated from definitions in the model.
+
+And putting it all together, we need to define the top-level application processes that are the entry point for each system component:
+
+**Processes**:
+```
+// Helpers to convert model definitions to TS
+def toTsTypedIden(var: Variable)
+  typescript:
+    {{ var.name }}: {{ var.type }}
+  end
+end
+
+def toTsAction(act: Action)
+  typescript:
+    async {{ act.name }}({{ act.args.map(toTsTypedIden) }}) {
+      {{ act.body }}
+    }
+  end
+end
+
+// Generates a client.ts file.
+//
+// This is a stateful class which holds all of the state variables
+// declared the model, and since toTsAction is called in a client block 
+// here, the client effect definition is used as the action body.
+process client:
+  typescript:
+    class Client {
+      {{ Model.variables.map(toTsTypedIden) }}
+
+      {{ Model.actions.map(toTsAction) }}
+    }
+  end
+end
+
+// Generates a server.ts file
+process server:
+  // generate web server bootstrap
+end
+```
+
+I omitted the server code for brevity, but that can all be generated from the Model in the same way.
+
+We didn't cover test generation, but with even less help, a model-based test can be generated here since we have all of the definitions that we need to compare actions in the implementation and model.

--- a/lib/certification.ml
+++ b/lib/certification.ml
@@ -81,8 +81,11 @@ let action_type action =
     let action_name = action.action_ast.aname in
     let action_type_name = Printf.sprintf "%sType" action_name in
     let state_vars = List.map to_interface_property action.state_vars in
+    let args = List.map to_interface_property action.action_ast.args in
 
-    TSInterface(action_type_name, state_vars)
+    let properties = List.concat [state_vars; args] in
+
+    TSInterface(action_type_name, properties)
 
 let generate_spec _ model_proc _ cert_out env =
   let action_types = List.map action_type model_proc.actions in

--- a/lib/certification.ml
+++ b/lib/certification.ml
@@ -135,6 +135,9 @@ let assert_state_var attr =
     )]
   ))
 
+let to_db_setup attr =
+  Core.({oname=attr.name; oval=to_db_access attr})
+
 let to_impl_arg attr =
   (* object propr *)
   Core.({oname=attr.name; oval=TSAccess(TSIden({iname="state"; itype=None}), TSIden({iname=attr.name; itype=None}))})
@@ -149,7 +152,9 @@ let test_body act =
   let create_impl = TSLet("impl", TSFuncCall("makeStore", [])) in
 
   let impl_set_state_args = List.map to_impl_arg act.state_vars in
-  let set_impl_state = TSMethodCall("impl", "setState", [TSObject(impl_set_state_args)]) in
+  let set_impl_state_client = TSMethodCall("impl", "setState", [TSObject(impl_set_state_args)]) in
+
+  let set_impl_state_server = TSMethodCall("impl", "setDBState", [TSObject(List.map to_db_setup act.state_vars)]) in
 
   let action_args = List.map to_state_access act.action_ast.args in
   let invoke_action_model = TSMethodCall("model", act.action_ast.aname, action_args) in
@@ -163,7 +168,8 @@ let test_body act =
   List.concat [
     [create_model;
     create_impl;
-    set_impl_state;
+    set_impl_state_client;
+    set_impl_state_server;
     invoke_action_model;
     get_impl_state;
     invoke_action_impl;

--- a/lib/certification.ml
+++ b/lib/certification.ml
@@ -137,7 +137,7 @@ let test_body act =
   let invoke_action_model = TSMethodCall("model", act.action_ast.aname, action_args) in
   
   let get_impl_state = TSLet("implState", TSMethodCall("impl", "getState", [])) in
-  let invoke_action_impl = TSMethodCall("implState", act.action_ast.aname, action_args) in
+  let invoke_action_impl = TSAwait(TSMethodCall("implState", act.action_ast.aname, action_args)) in
   
   (* let apply_refinement_mapping = TSNum(5) in *)
   let assert_results = List.map assert_state_var act.state_vars in
@@ -213,7 +213,7 @@ let generate_spec _ model_proc _ cert_out env =
 
   let imports = {|import { expect, test } from 'vitest';
   import { makeStore } from '../lib/state';
-  import { Counter } from '../lib/model';
+  import { Counter } from './model';
   import fc from 'fast-check';
   |} in
 

--- a/lib/certification.ml
+++ b/lib/certification.ml
@@ -210,7 +210,6 @@ let generate_spec _ model_proc _ cert_out env =
   let env_types = List.map (fun s -> schema_to_interface s (Env.SchemaEnv.find s env.schemas)) schema_names in
   let action_types = List.map action_type model_proc.actions in
   let action_tests = List.map to_action_test model_proc.actions in
-  let db_type_ts = List.map db_type_ts model_proc.actions in
 
   let imports = {|import { expect, test } from 'vitest';
   import { makeStore } from '../lib/state';
@@ -220,7 +219,6 @@ let generate_spec _ model_proc _ cert_out env =
 
   let everything = List.concat [
     env_types; 
-    db_type_ts; 
     action_types; 
     action_tests
   ] in

--- a/lib/certification.ml
+++ b/lib/certification.ml
@@ -413,7 +413,7 @@ let to_witness_element env act =
 
   TSEOSExpr(TSObject(witness_props))
 
-let generate_spec _ model_proc _ cert_out env =
+let generate_spec model_proc cert_out env =
   let db_types = List.map (fun a -> Entity(db_type_name a, a.state_vars)) model_proc.actions in
   let env = List.fold_left (fun e s -> Env.add_stmt_to_env s e) env db_types in
 

--- a/lib/certification.ml
+++ b/lib/certification.ml
@@ -105,6 +105,11 @@ let to_tstyped_attr attr =
 
   Core.({ tsname=attr.name; tstyp=Option.value tstyp ~default:(TSTCustom("no type")) } )  
 
+  (* Accesses a part of the state from the db *)
+let to_db_access attr =
+  TSAccess(TSIden({iname="state.db"; itype=None}), TSIden({iname=Core.(attr.name); itype=None}))
+
+  (* Accesses a part of the client-side *)
 let to_state_access attr =
   TSAccess(TSIden({iname="state"; itype=None}), TSIden({iname=Core.(attr.name); itype=None}))
 
@@ -125,7 +130,7 @@ let to_impl_arg attr =
 
   (* The property-based test body - the actual test logic lives here*)
 let test_body act =
-  let model_state_args = List.map to_state_access act.state_vars in
+  let model_state_args = List.map to_db_access act.state_vars in
   let create_model = TSLet("model", TSNew("Counter", model_state_args)) in
 
   let create_impl = TSLet("impl", TSFuncCall("makeStore", [])) in

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -152,12 +152,55 @@ and string_of_builtin n args attrs (env: Env.env) =
     Printf.sprintf {|
     %s.map((a) => %s(a))
     |} arr map_func
+  | "update" ->
+    let arr = string_of_expr (List.nth args 0) attrs env in
+    let finder = string_of_expr (List.nth args 1) attrs env in
+    let updater = string_of_expr (List.nth args 2) attrs env in
+
+    Printf.sprintf {|
+    (() => {
+      const index = %s.findIndex((a) => %s(a));
+      let ret = [...%s];
+      ret[index] = %s(ret[index]);
+
+      return ret;
+    })();
+    |} arr finder arr updater
   | "equals" ->
     let larg = string_of_expr (List.nth args 0) attrs env in
     let rarg = string_of_expr (List.nth args 1) attrs env in
 
     Printf.sprintf {|
     %s === %s
+    |} larg rarg
+  | "equalsStr" ->
+    let larg = string_of_expr (List.nth args 0) attrs env in
+    let rarg = string_of_expr (List.nth args 1) attrs env in
+
+    Printf.sprintf {|
+    %s === %s
+    |} larg rarg
+
+  | "notEqualsStr" ->
+    let larg = string_of_expr (List.nth args 0) attrs env in
+    let rarg = string_of_expr (List.nth args 1) attrs env in
+
+    Printf.sprintf {|
+    %s !== %s
+    |} larg rarg    
+  | "index" ->
+    let larg = string_of_expr (List.nth args 0) attrs env in
+    let rarg = string_of_expr (List.nth args 1) attrs env in
+
+    Printf.sprintf {|
+    %s[%s]
+    |} larg rarg
+  | "filter" ->
+    let larg = string_of_expr (List.nth args 0) attrs env in
+    let rarg = string_of_expr (List.nth args 1) attrs env in
+
+    Printf.sprintf {|
+    %s.filter(%s)
     |} larg rarg
   | _ -> failwith (Printf.sprintf "Attempted to compile unknown builtin func: %s" n)  
 

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -371,7 +371,7 @@ let rec tsexpr_of_expr env e  =
 
     let body_with_return = List.concat [
       List.map to_tsexpr other_exprs;
-      List.map to_tsexpr [last_expr]
+      [TSReturn(to_tsexpr last_expr)]
     ] in
 
     TSLet(fdname, TSClosure(List.map tstyped_attr_of_typed_attr fdargs, body_with_return, false))

--- a/lib/codegen.ml
+++ b/lib/codegen.ml
@@ -43,6 +43,7 @@ let rec string_of_expr e attrs env = match e with
     | None -> string_of_iden i attrs)
   | Num(n) -> string_of_int n
   | Bool(b) -> string_of_bool b
+  | Plus(e1, e2) -> Printf.sprintf "%s + %s" (string_of_expr e1 attrs env) (string_of_expr e2 attrs env)
   | If(e1, e2, e3) -> (match e3 with
     | Some(else_e) ->
       let cond = string_of_expr e1 attrs env in
@@ -283,6 +284,7 @@ let rec tsexpr_of_expr e = match e with
   (* Not handling these, but should *)
   | FuncDef(_) -> failwith "Not handling FuncDef to TS"
   | Case(_, _) -> failwith "Not handling Case to TS"
+  | Plus(_, _) -> failwith "Not handling Plus to TS"
   
   (* Not handling these, and probably should never *)
   | Effect(_) -> failwith "Not handling Effect to TS"

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -56,18 +56,18 @@ let compile_spec input_file impl_in cert_out =
   lex.Lexing.lex_curr_p <- {lex.Lexing.lex_curr_p with Lexing.pos_fname = input_file};
 
   let init_process = Process.new_process () in
-  let init_interp_env = Interpreter.new_environment_with_builtins () in
+  (* let init_interp_env = Interpreter.new_environment_with_builtins () in *)
   let stmts = Parse.parse_with_error lex in
-  let interp_env = List.fold_left Interpreter.build_env init_interp_env stmts in
+  (* let interp_env = List.fold_left Interpreter.build_env init_interp_env stmts in *)
   let model_ast = Process.filter_model stmts in
   let model_proc = List.fold_left Process.analyze_model init_process model_ast in
-  let interp_env = Interpreter.add_model_to_env model_proc interp_env in
+  (* let interp_env = Interpreter.add_model_to_env model_proc interp_env in *)
   let env = List.fold_left (fun e s -> Env.add_stmt_to_env s e) Env.empty_env model_ast in
 
   File.output_str "model" (Codegen.string_of_model model_ast env);
 
   close_in fh;
-  Certification.generate_spec "model.ts" model_proc impl_in cert_out interp_env
+  Certification.generate_spec "model.ts" model_proc impl_in cert_out env
 
 let compile_str expr =
   compile (Lexing.from_string expr) "impl.ts" "refine_cert.ts"

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -50,7 +50,7 @@ let compile lexbuf impl_out cert_out =
   Certification.generate model_proc "model.ts" "impl.ts" cert_out interp_env env
 
 (* Compilers certifying specification *)
-let compile_cert_test input_file impl_in cert_out out_file =
+let compile_cert_test input_file cert_out =
   let fh = open_in input_file in
   let lex = Lexing.from_channel fh in
   lex.Lexing.lex_curr_p <- {lex.Lexing.lex_curr_p with Lexing.pos_fname = input_file};
@@ -61,10 +61,8 @@ let compile_cert_test input_file impl_in cert_out out_file =
   let model_proc = List.fold_left Process.analyze_model init_process model_ast in
   let env = List.fold_left (fun e s -> Env.add_stmt_to_env s e) Env.empty_env model_ast in
 
-  File.output_str out_file (Codegen.string_of_model model_ast env);
-
   close_in fh;
-  Certification.generate_spec "model.ts" model_proc impl_in cert_out env
+  Certification.generate_spec model_proc cert_out env
 
 let compile_str expr =
   compile (Lexing.from_string expr) "impl.ts" "refine_cert.ts"

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -50,7 +50,7 @@ let compile lexbuf impl_out cert_out =
   Certification.generate model_proc "model.ts" "impl.ts" cert_out interp_env env
 
 (* Compilers certifying specification *)
-let compile_spec input_file impl_in cert_out out_file =
+let compile_cert_test input_file impl_in cert_out out_file =
   let fh = open_in input_file in
   let lex = Lexing.from_channel fh in
   lex.Lexing.lex_curr_p <- {lex.Lexing.lex_curr_p with Lexing.pos_fname = input_file};

--- a/lib/compiler.ml
+++ b/lib/compiler.ml
@@ -50,21 +50,18 @@ let compile lexbuf impl_out cert_out =
   Certification.generate model_proc "model.ts" "impl.ts" cert_out interp_env env
 
 (* Compilers certifying specification *)
-let compile_spec input_file impl_in cert_out =
+let compile_spec input_file impl_in cert_out out_file =
   let fh = open_in input_file in
   let lex = Lexing.from_channel fh in
   lex.Lexing.lex_curr_p <- {lex.Lexing.lex_curr_p with Lexing.pos_fname = input_file};
 
   let init_process = Process.new_process () in
-  (* let init_interp_env = Interpreter.new_environment_with_builtins () in *)
   let stmts = Parse.parse_with_error lex in
-  (* let interp_env = List.fold_left Interpreter.build_env init_interp_env stmts in *)
   let model_ast = Process.filter_model stmts in
   let model_proc = List.fold_left Process.analyze_model init_process model_ast in
-  (* let interp_env = Interpreter.add_model_to_env model_proc interp_env in *)
   let env = List.fold_left (fun e s -> Env.add_stmt_to_env s e) Env.empty_env model_ast in
 
-  File.output_str "model" (Codegen.string_of_model model_ast env);
+  File.output_str out_file (Codegen.string_of_model model_ast env);
 
   close_in fh;
   Certification.generate_spec "model.ts" model_proc impl_in cert_out env

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -166,10 +166,15 @@ and ts_type =
   | TSTCustom of string
   | TSTGeneric of string * ts_type list
 
+and ts_func_decl_arg = {
+  tattr: tstyped_attr;
+  default_val: tsexpr option;
+}
+
 and tsclassdef =
   | CDSLExpr of expr
   | TSClassProp of string * ts_type
-  | TSClassMethod of string * tstyped_attr list * tsexpr list * bool
+  | TSClassMethod of string * ts_func_decl_arg list * tsexpr list * bool
 
 let tsClassProp name typ = TSClassProp(name, typ)
 

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -45,6 +45,7 @@ type expr =
   | Bool of bool
   | Iden of string * sligh_type option
   | Num of int
+  | Plus of expr * expr
   | Array of expr list
   | If of expr * expr * expr option
   | StmtList of expr list

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -131,8 +131,7 @@ and tsexpr =
 | SLExpr of expr
 | SLSpliceExpr of expr
 
-and obj_prop = {
-  oname: string;
+and obj_prop = { oname: string;
   oval: tsexpr;
 }
 

--- a/lib/core.ml
+++ b/lib/core.ml
@@ -114,13 +114,19 @@ and tsexpr =
 | TSFuncCall of string * tsexpr list
 | TSClass of string * tsclassdef list
 | TSIf of tsexpr * tsexpr * tsexpr option
-| TSArray of tsexpr list
+| TSArray of tsexpr_or_spread list
 | TSString of string
+| TSPlus of tsexpr * tsexpr
 | TSReturn of tsexpr
 | TSAccess of tsexpr * tsexpr
+| TSIndex of tsexpr * tsexpr
 | TSAssignment of tsexpr * tsexpr
 | TSInterface of string * tstyped_attr list
+| TSEqual of tsexpr * tsexpr
+| TSNotEqual of tsexpr * tsexpr
 | TSClosure of tsparam list * tsexpr list * bool
+(* Can only immediately invoke a closure *)
+| TSImmediateInvoke of tsexpr
 | TSObject of obj_prop list
 | TSNew of string * tsexpr list
 | TSAwait of tsexpr
@@ -131,7 +137,12 @@ and tsexpr =
 | SLExpr of expr
 | SLSpliceExpr of expr
 
-and obj_prop = { oname: string;
+and tsexpr_or_spread = 
+  | TSEOSExpr of tsexpr
+  | TSEOSSpread of string
+
+and obj_prop = {
+  oname: string;
   oval: tsexpr;
 }
 

--- a/lib/effects.ml
+++ b/lib/effects.ml
@@ -117,6 +117,13 @@ and apply_tsexpr proc_name effect_env interp_env tse =
   | TSNew(_, _) -> Some(tse)
   | TSReturn(_) -> Some(tse)
   | TSCast(_) -> Some(tse)
+  | TSPlus(_) -> Some(tse)
+  | TSImmediateInvoke(_) -> Some(tse)
+  | TSEqual(_, _) -> Some(tse)
+  | TSNotEqual(_, _) -> Some(tse)
+
+  | TSIndex(_, _) -> Some(tse)
+
 and apply_tsclassdef proc_name effect_env interp_env cd = match cd with
   | TSClassMethod(nm, args, body, ia) -> TSClassMethod(nm, args, List.filter_map (fun tse -> apply_tsexpr proc_name effect_env interp_env tse) body, ia)
   | _ -> cd

--- a/lib/env.ml
+++ b/lib/env.ml
@@ -10,6 +10,7 @@ type env = {
 }
 
 let empty_env = {
+  (* Need variants too *)
   schemas=SchemaEnv.empty
 }
 

--- a/lib/file.ml
+++ b/lib/file.ml
@@ -12,10 +12,13 @@ let print ps =
   Files.iter (fun k v -> Printf.printf "%s -> %s\n" k (Util.string_of_stmt_list v)) ps
 
 let output_str file_name strg =  
-  let fname = Printf.sprintf "%s.ts" file_name in
-  let open_chan = open_out fname in
+  let open_chan = open_out file_name in
   Printf.fprintf open_chan "%s\n" strg;
   close_out open_chan
+
+let output_tsexpr_list_imports file_name env tss imports =
+    let ts = (String.concat "\n\n" (List.map (fun t -> Codegen.string_of_ts_expr t env) tss)) in
+    output_str file_name (Printf.sprintf "%s\n\n%s" imports ts)
 
 let output_tsexpr_list file_name env tss =
   output_str file_name (String.concat "\n\n" (List.map (fun t -> Codegen.string_of_ts_expr t env) tss))

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -423,6 +423,16 @@ let all_builtins = [
     fdargs=[{name="s1";typ=STString}; {name="s2";typ=STString}];
     fdbody=[];
   }};
+  {bname="notEqualsStr"; bdef={
+    fdname="notEqualsStr";
+    fdargs=[{name="s1";typ=STString}; {name="s2";typ=STString}];
+    fdbody=[];
+  }};
+  {bname="update"; bdef={
+    fdname="update";
+    fdargs=[{name="finder";typ=STString}; {name="updater";typ=STString}];
+    fdbody=[];
+  }};
   {bname="and"; bdef={
     fdname="and";
     fdargs=[{name="b1";typ=STString}; {name="b2";typ=STString}];

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -931,8 +931,8 @@ and eval_builtin_func name args env =
           | VType(tv) -> ts_type_of_type_val tv
           | _ -> failwith "not a type val" in
 
-        {tsname=name; tstyp= typ}
-      | VTSTypedAttr(ta) -> ta
+        {tattr={tsname=name; tstyp= typ}; default_val=None}
+      | VTSTypedAttr(ta) -> {tattr=ta; default_val=None}
       | _ -> failwith (Printf.sprintf "Calling tsClassMethod, args not array of instances %s" (string_of_value arg))) args_arg in
 
     let body_arg = List.nth args 2 |> val_as_tsexpr_list in

--- a/lib/interpreter.ml
+++ b/lib/interpreter.ml
@@ -1076,6 +1076,7 @@ and eval_ts ts_expr env = match ts_expr with
   let res: value = eval e env |> fst in
   (tsexpr_of_val_splice res, env)
 | TSLet(var, exp) -> ([TSLet(var, eval_ts exp env |> fst |> List.hd)], env)
+| TSPlus(e1, e2) -> ([TSPlus(eval_ts e1 env |> fst |> List.hd, eval_ts e2 env |> fst |> List.hd)], env)
 | TSMethodCall(recv, call, args) ->
     let reduced_args = List.concat_map (fun a -> eval_ts a env |> fst) args in
     ([TSMethodCall(recv, call, reduced_args)], env)
@@ -1106,11 +1107,15 @@ and eval_ts ts_expr env = match ts_expr with
 | TSIden _ -> ([ts_expr], env)
 | TSNum _ ->  ([ts_expr], env)
 | TSBool(_) -> ([ts_expr], env)
+| TSEqual(_, _) -> ([ts_expr], env)
+| TSNotEqual(_, _) -> ([ts_expr], env)
+
 | TSClass (_, _) -> ([ts_expr], env) 
 | TSArray _ -> ([ts_expr], env) 
 | TSString _ -> ([ts_expr], env)
 | TSAccess (_, _) -> ([ts_expr], env)
 | TSAssignment (_, _) -> ([ts_expr], env)
+| TSIndex(_, _) -> ([ts_expr], env)
 | TSInterface (_, _) -> ([ts_expr], env)
 | TSClosure (_, _, _) -> ([ts_expr], env)
 | TSAwait _ -> ([ts_expr], env)
@@ -1119,10 +1124,13 @@ and eval_ts ts_expr env = match ts_expr with
 | TSDefaultImport(_, _) -> ([ts_expr], env)
 | TSNew(_, _) -> ([ts_expr], env)
 
+(* Idk about this one *)
+| TSImmediateInvoke(_) -> ([ts_expr], env)
+
 and tsexpr_of_val (v: value) = match v with
 | VNum(n) -> TSNum(n)
 | VTS(tss) -> TSStmtList(tss)
-| VArray(vs) -> TSArray(List.map tsexpr_of_val vs)
+| VArray(vs) -> TSArray(List.map (fun v -> TSEOSExpr(tsexpr_of_val v)) vs)
 | VString(s) -> TSString(s)
 | VTSExpr(e) -> e
 | VSLExpr(e) -> SLExpr(e)

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -48,6 +48,7 @@ rule read ctx = parse
   | "="               { EQUALS }
   | "|"               { BAR }
   | "_"               { UNDERSCORE }
+  | "+"               { PLUS }
   | "let"             { LET }
   | "end"             { END }
   | "def"             { DEF }

--- a/lib/lexer.mll
+++ b/lib/lexer.mll
@@ -53,7 +53,7 @@ rule read ctx = parse
   | "end"             { END }
   | "def"             { DEF }
   | "process"         { PROCESS }
-  | "entity"          { ENTITY }
+  | "record"          { ENTITY }
   | "file"            { FILE }
   | "implementation"  { IMPLEMENTATION }
   | "rewrite"          { EFFECT }

--- a/lib/parser.mly
+++ b/lib/parser.mly
@@ -49,6 +49,7 @@ open Interpreter
 %token RSQBRACKET
 %token ASSIGNMENT
 %token SEMICOLON
+%token PLUS
 
 // %left ASSIGNMENT
 // %right LPAREN
@@ -112,6 +113,7 @@ expression:
   | assignment                                    { $1 }
   | n = NUMBER                                    { Num(n) }
   | variable                                      { $1 }
+  | e1 = expression PLUS e2 = expression          { Plus(e1, e2) }
   | func_call                                     { $1 }
   | s = STRING                                    { String(s) }
   | LSQBRACKET es = separated_list(COMMA, expression) RSQBRACKET

--- a/lib/process.ml
+++ b/lib/process.ml
@@ -8,6 +8,7 @@ type schema = {
 type action = {
   action_ast: Core.proc_action;
   state_vars: Core.typed_attr list;
+  assignments: (string * Core.expr) list
 }
 
 type variant = {
@@ -46,82 +47,136 @@ let collect_attrs attrs def = match def with
 
 let filter_attrs (defs: proc_def list): typed_attr list  = List.fold_left collect_attrs [] defs
 
-let rec collect_state_vars state_vars e (proc_attrs: typed_attr list): typed_attr list =
+type action_info = {
+  vars: typed_attr list;
+  assigns: (string * Core.expr) list
+}
+
+let empty_action_info =
+  { vars=[]; assigns=[] }
+
+let rec collect_action_info action_info e (proc_attrs: typed_attr list): action_info =
   match e with
-  | Let(_, value) -> state_vars @ collect_state_vars [] value proc_attrs
+  | Let(_, value) -> 
+    let info = collect_action_info empty_action_info value proc_attrs in 
+    let vars = info.vars @ action_info.vars in
+    let assigns = info.assigns @ action_info.assigns in
+
+    { vars; assigns }
   | Assignment(var, e) ->
     (* Failure to find attr here means assignment is on a non-state variable *)
     let proc_attr = List.find (fun attr -> Core.(attr.name = var)) proc_attrs in
+    let info = collect_action_info empty_action_info e proc_attrs in
+    let vars = {name=var; typ=proc_attr.typ} :: info.vars in
+    let assigns = (var, e) :: info.assigns in 
 
-    {name=var; typ=proc_attr.typ} :: state_vars @ collect_state_vars [] e proc_attrs
+    { vars; assigns }
   | Iden(i, _) ->
     let proc_attr = List.find_opt (fun attr -> Core.(attr.name = i)) proc_attrs in
 
     (match proc_attr with
-    | Some(pa) -> {name=i; typ=pa.typ} :: state_vars
-    | None -> state_vars)
-  | Plus(e1, e2) -> 
-    state_vars @ collect_state_vars [] e1 proc_attrs @ collect_state_vars [] e2 proc_attrs
-  | Array(es) ->
-      List.concat_map
-        (fun e -> collect_state_vars [] e proc_attrs)
-        es @ state_vars 
-  | If(cond, then_e, else_e) ->
-    let else_state_vars: typed_attr list = match else_e with
-      | Some(ee) -> collect_state_vars [] ee proc_attrs
-      | None -> [] in
+    | Some(pa) -> 
+      let vars = {name=i; typ=pa.typ} :: action_info.vars in
 
-    collect_state_vars [] cond proc_attrs @
-    collect_state_vars [] then_e proc_attrs @ else_state_vars
+      { action_info with vars }
+    | None -> action_info)
+  | Plus(e1, e2) -> 
+    let info_e1 = collect_action_info empty_action_info e1 proc_attrs in
+    let info_e2 = collect_action_info empty_action_info e2 proc_attrs in 
+    let vars = info_e1.vars @ info_e2.vars in
+    let assigns = info_e1.assigns @ info_e2.assigns in
+
+    { vars; assigns }
+  | Array(es) ->
+      List.fold_left
+        (fun ai e -> 
+          let info = collect_action_info empty_action_info e proc_attrs in 
+
+          { vars=info.vars @ ai.vars; assigns=info.assigns @ ai.assigns }
+        )
+        empty_action_info
+        es
+  | If(cond, then_e, else_e) ->
+    let else_info = match else_e with
+      | Some(ee) -> collect_action_info empty_action_info ee proc_attrs
+      | None -> empty_action_info in
+    let cond_info = collect_action_info empty_action_info cond proc_attrs in
+    let then_info = collect_action_info empty_action_info then_e proc_attrs in
+    let vars = else_info.vars @ cond_info.vars @ then_info.vars in
+    let assigns = else_info.assigns @ cond_info.assigns @ then_info.assigns in
+    
+    { vars; assigns }
   | StmtList(es) ->
-    List.concat_map
-      (fun e -> collect_state_vars [] e proc_attrs)
-      es @ state_vars
+    List.fold_left
+        (fun ai e -> 
+          let info = collect_action_info empty_action_info e proc_attrs in 
+
+          { vars=info.vars @ ai.vars; assigns=info.assigns @ ai.assigns }
+        )
+        empty_action_info
+        es
   | Call(_, args) ->
-    List.concat_map
-      (fun e -> collect_state_vars [] e proc_attrs)
-      args @ state_vars
+    List.fold_left
+        (fun ai e -> 
+          let info = collect_action_info empty_action_info e proc_attrs in 
+
+          { vars=info.vars @ ai.vars; assigns=info.assigns @ ai.assigns }
+        )
+        empty_action_info
+        args
 
   | Access(l, r) ->
     let proc_attr = List.find_opt (fun attr -> Core.(attr.name = r)) proc_attrs in
 
     (match proc_attr with
     | Some(pa) ->
-      let l_state_vars = collect_state_vars [] l proc_attrs in
+      let l_info = collect_action_info empty_action_info l proc_attrs in
+      let vars = {name=r; typ=pa.typ} :: l_info.vars in
 
-      {name=r; typ=pa.typ} :: state_vars @ l_state_vars
-    | None -> state_vars)
+      { action_info with vars }
+    | None -> action_info)
   | Case(e, cases) ->
-    collect_state_vars [] e proc_attrs @
-    (List.concat_map (fun c -> collect_state_vars [] c.value proc_attrs) cases) @
-    state_vars
+    let cases_info = List.fold_left
+      (fun ai e -> 
+        let info = collect_action_info empty_action_info e.value proc_attrs in 
 
-  | String(_) -> state_vars
-  | Num(_) -> state_vars
-  | Bool(_) -> state_vars
+        { vars=info.vars @ ai.vars; assigns=info.assigns @ ai.assigns }
+      )
+      empty_action_info
+      cases in
+    let e_info = collect_action_info empty_action_info e proc_attrs in
+
+    { vars=cases_info.vars @ e_info.vars; assigns=cases_info.assigns @ e_info.assigns}
+  | String(_) -> action_info
+  | Num(_) -> action_info
+  | Bool(_) -> action_info
 
    (* Should only be decl, possibly only be class decl *)
-  | Implementation(_) -> state_vars
-  | FuncDef(_) -> state_vars
-  | File(_) -> state_vars
-  | Effect(_) -> state_vars
-  | Process(_, _) -> state_vars
-  | Entity(_, _) -> state_vars
-  | TS(_) -> state_vars
-  | Variant(_, _) -> state_vars
+  | Implementation(_) -> action_info
+  | FuncDef(_) -> action_info
+  | File(_) -> action_info
+  | Effect(_) -> action_info
+  | Process(_, _) -> action_info
+  | Entity(_, _) -> action_info
+  | TS(_) -> action_info
+  | Variant(_, _) -> action_info
 
-let state_vars_of_action (action: Core.proc_action) (proc_attrs: typed_attr list) =
-  List.fold_left
-    (fun state_vars e -> collect_state_vars state_vars e proc_attrs)
-    []
-    action.body
-    (* collect_state_vars is returning duplicates - should ultimately fix that instead
-       of this unique sort *)
-    |> List.sort_uniq (fun sv1 sv2 -> Core.(compare sv1.name sv2.name))
+let action_info_of_action (action: Core.proc_action) (proc_attrs: typed_attr list) =
+  let info = List.fold_left
+    (fun action_info e -> collect_action_info action_info e proc_attrs)
+    empty_action_info
+    action.body in
+
+  let vars = List.sort_uniq (fun sv1 sv2 -> Core.(compare sv1.name sv2.name)) info.vars in
+  let assigns = List.sort_uniq (fun a1 a2 -> compare (fst a1) (fst a2)) info.assigns in
+
+  { vars; assigns }
 
 let analyze_action actions action proc_attrs =
+  let info = action_info_of_action action proc_attrs in
   {
-    state_vars=state_vars_of_action action proc_attrs;
+    state_vars=info.vars;
+    assignments=info.assigns;
     action_ast=action;
   } :: actions
   
@@ -157,9 +212,11 @@ let print_variable v =
   Printf.printf "Var: %s\n" (Util.string_of_typed_attr v)
 
 let print_action a =
-  Printf.printf "Action: \n  ast: %s\n\n  state_vars: %s\n"
+  Printf.printf "Action: \n  ast: %s\n\n  state_vars: %s\n assignments: %s\n"
     (Util.string_of_proc_action a.action_ast)
     (String.concat "\n" (List.map Util.string_of_typed_attr a.state_vars))
+    (String.concat "\n" (List.map Util.string_of_typed_attr a.state_vars))
+
 
 let print_process m =
   print_endline "Process.schemas";

--- a/lib/process.ml
+++ b/lib/process.ml
@@ -60,10 +60,12 @@ let rec collect_state_vars state_vars e (proc_attrs: typed_attr list): typed_att
     (match proc_attr with
     | Some(pa) -> {name=i; typ=pa.typ} :: state_vars
     | None -> state_vars)
+  | Plus(e1, e2) -> 
+    state_vars @ collect_state_vars [] e1 proc_attrs @ collect_state_vars [] e2 proc_attrs
   | Array(es) ->
       List.concat_map
         (fun e -> collect_state_vars [] e proc_attrs)
-        es @ state_vars
+        es @ state_vars 
   | If(cond, then_e, else_e) ->
     let else_state_vars: typed_attr list = match else_e with
       | Some(ee) -> collect_state_vars [] ee proc_attrs

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -33,6 +33,7 @@ let rec string_of_expr e = match e with
     | Some(t) -> Printf.sprintf "%s: %s" i (string_of_type t)
     | None -> i)
   | Num(n) -> string_of_int n
+  | Plus(e1, e2) -> Printf.sprintf "%s + %s" (string_of_expr e1) (string_of_expr e2)
   | Bool(b) -> if b then "true" else "false"
   | If(e1, e2, e3) -> (match e3 with
     | Some(elseE) -> Printf.sprintf "if  %s:\n %s\nelse:\n  %send" (string_of_expr e1) (string_of_expr e2) (string_of_expr elseE)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -108,14 +108,18 @@ and string_of_tsparam tsp = match tsp with
 and string_of_tsobject_pat op = 
   Printf.sprintf "{ %s }: %s" (String.concat ", " (List.map string_of_tsobject_pat_prop op.opprops)) (string_of_tstype op.optyp)
 
-and string_of_tsobject_pat_prop opp = Printf.sprintf "%s: %s" opp.oppname opp.oppvalue  
+and string_of_tsobject_pat_prop opp = Printf.sprintf "%s: %s" opp.oppname opp.oppvalue
+
+and string_of_tsfunc_decl_arg a = match a.default_val with
+| Some(e) -> Printf.sprintf "%s = %s" (string_of_ts_typed_attr a.tattr) (string_of_ts_expr e)
+| None -> string_of_ts_typed_attr a.tattr
 
 and string_of_tsclassdef cd = match cd with
 | TSClassProp(n, typ) -> Printf.sprintf "ts-%s: ts-%s" n (string_of_tstype typ)
 | TSClassMethod(nm, args, body, is_async) -> if is_async then
-  Printf.sprintf "async ts-class-meth %s(%s) {\n\t%s\n}" nm (String.concat "," (List.map string_of_ts_typed_attr args)) (List.map string_of_ts_expr body |> print_list "\n")
+  Printf.sprintf "async ts-class-meth %s(%s) {\n\t%s\n}" nm (String.concat "," (List.map string_of_tsfunc_decl_arg args)) (List.map string_of_ts_expr body |> print_list "\n")
 else
-  Printf.sprintf "ts-class-meth %s(%s) {\n\t%s\n}" nm (String.concat "," (List.map string_of_ts_typed_attr args)) (List.map string_of_ts_expr body |> print_list "\n")
+  Printf.sprintf "ts-class-meth %s(%s) {\n\t%s\n}" nm (String.concat "," (List.map string_of_tsfunc_decl_arg args)) (List.map string_of_ts_expr body |> print_list "\n")
 
 | CDSLExpr(_) -> "CDSLExpr remove"
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -64,12 +64,15 @@ and string_of_ts_expr e = match e with
   | TSIden(i) -> string_of_tsiden i
   | TSNum(n) -> "ts-" ^ string_of_int n
   | TSBool(b) -> string_of_bool b
+  | TSEqual(e1, e2) -> Printf.sprintf "%s === %s" (string_of_ts_expr e1) (string_of_ts_expr e2)
+  | TSNotEqual(e1, e2) -> Printf.sprintf "%s !== %s" (string_of_ts_expr e1) (string_of_ts_expr e2)
   | TSLet(v, ie) -> "ts-let ts-" ^ v ^ " = " ^ string_of_ts_expr ie
+  | TSPlus(e1, e2) -> Printf.sprintf "%s + %s" (string_of_ts_expr e1) (string_of_ts_expr e2)
   | TSStmtList(ss) -> String.concat "\n" (List.map string_of_ts_expr ss)
   | TSClass(n, ds) -> Printf.sprintf "ts-class %s\n\t%s" n (String.concat "\n" (List.map string_of_tsclassdef ds))
   | TSMethodCall(recv, m, args) -> Printf.sprintf "ts-%s.%s(%s)" recv m (List.map string_of_ts_expr args |> print_list "\n")
   | TSFuncCall(f, args) -> Printf.sprintf "%s(%s)" f (List.map string_of_ts_expr args |> print_list "\n")
-  | TSArray(es) -> Printf.sprintf "[%s]" (String.concat ", " (List.map string_of_ts_expr es))
+  | TSArray(es) -> Printf.sprintf "[%s]" (String.concat ", " (List.map string_of_tsexpr_or_pat es))
   | TSReturn(e) -> Printf.sprintf "return %s" (string_of_ts_expr e)
   | TSCast(e, cast) -> Printf.sprintf "%s as %s" (string_of_ts_expr e) cast
   | TSString(s) -> s
@@ -78,11 +81,16 @@ and string_of_ts_expr e = match e with
     | None -> Printf.sprintf "if (%s) {\n %s\n}" (string_of_ts_expr e1) (string_of_ts_expr e2))
   | TSAccess(e1, e2) -> Printf.sprintf "%s.%s" (string_of_ts_expr e1) (string_of_ts_expr e2)
   | TSAssignment(e1, e2) -> Printf.sprintf "%s = %s" (string_of_ts_expr e1) (string_of_ts_expr e2)
+  | TSIndex(e1, e2) -> Printf.sprintf "%s[%s]" (string_of_ts_expr e1) (string_of_ts_expr e2)
   | TSInterface(n, attrs) -> Printf.sprintf "ts-interface %s {\n %s\n}" n (String.concat "\n" (List.map string_of_ts_typed_attr attrs))
   | TSClosure(args, body, is_async) -> if is_async then
       Printf.sprintf "async (%s) => {\n  %s\n}" (String.concat ", " (List.map string_of_tsparam args)) (print_list "\n" (List.map string_of_ts_expr body))
     else 
       Printf.sprintf "(%s) => {\n  %s\n}" (String.concat ", " (List.map string_of_tsparam args)) (print_list "\n" (List.map string_of_ts_expr body))
+  | TSImmediateInvoke(c) -> (match c with
+    | TSClosure(_, _, _) ->
+      Printf.sprintf "(%s)()" (string_of_ts_expr c)
+    | _ -> failwith "Can only immediately invoke a closure")
   | TSObject(props) -> Printf.sprintf "{%s}" (String.concat ",\n" (List.map string_of_obj_prop props))
   | TSAwait(e) -> Printf.sprintf "await %s" (string_of_ts_expr e)
   | TSExport(e) -> Printf.sprintf "export %s" (string_of_ts_expr e)
@@ -94,6 +102,10 @@ and string_of_ts_expr e = match e with
   | TSNew(c, args) -> Printf.sprintf "new %s(%s)" c (String.concat ", " (List.map string_of_ts_expr args))
   | SLSpliceExpr(_) -> "SLSpliceExpr"
   | SLExpr(e) -> string_of_expr e
+
+and string_of_tsexpr_or_pat eop = match eop with
+  | TSEOSExpr(e) -> string_of_ts_expr e
+  | TSEOSSpread(n) -> Printf.sprintf "...%s" n
 
 and string_of_obj_prop p = Printf.sprintf "%s: %s" p.oname (string_of_ts_expr p.oval)
 


### PR DESCRIPTION
This branch changes the predominant paradigm of Sligh to focus only on test generation from a model. This is basically a certifying compiler without the implementation compilation step, which I'm calling "certifying specification," but model-based testing might also be accurate.

The approach is to analyze a Sligh model and generate a witness from it. The witness has information that a separate test generator can use to generate actual tests. 